### PR TITLE
Fix compiltion under Java 7

### DIFF
--- a/src/main/java/uniol/aptgui/module/ModulePresenterImpl.java
+++ b/src/main/java/uniol/aptgui/module/ModulePresenterImpl.java
@@ -126,7 +126,7 @@ public class ModulePresenterImpl extends AbstractPresenter<ModulePresenter, Modu
 		}
 	}
 
-	private Future<List<Object>> invokeModule(Object[] paramValues) {
+	private Future<List<Object>> invokeModule(final Object[] paramValues) {
 		return executor.submit(new Callable<List<Object>>() {
 			@Override
 			public List<Object> call() throws Exception {


### PR DESCRIPTION
Error message is:

```
   ModulePresenterImpl.java:134: error: local variable paramValues is accessed
   from within inner class; needs to be declared final

   List<Object> filledReturnValues = invoker.invoke(module, paramValues);
                                                            ^
```

As far as I remember Java 8 has something like "implicitly final variables" which are variables which are never modified. However, Google failed to find anything like, so I'm not sure. At least this would explain why things work with Java 8.

I've been playing around a bit with Travis and as far as I know this project is supposed to work with Java 7 (you explicitly avoided some Java 8 features), so here is a simple patch.

Travis build: https://travis-ci.org/psychon/apt-gui/builds/134445726
`.travis.yml`: https://github.com/psychon/apt-gui/blob/ecdef42f7153b994af40afb64e2e0e712ec0c073/.travis.yml (No idea if that mail address is a good idea in there...)
