### PR TITLE
Implement a Graphviz/Dot layout

### DIFF
--- a/src/main/java/uniol/aptgui/editor/layout/GraphvizLayout.java
+++ b/src/main/java/uniol/aptgui/editor/layout/GraphvizLayout.java
@@ -1,0 +1,141 @@
+/*-
+ * APT - Analysis of Petri Nets and labeled Transition systems
+ * Copyright (C) 2016 Jonas Prellberg
+ * Copyright (C) 2016 Uli Schlachter
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package uniol.aptgui.editor.layout;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import java.awt.Point;
+
+import uniol.apt.io.parser.ParseException;
+
+import uniol.aptgui.Application;
+import uniol.aptgui.editor.document.Document;
+import uniol.aptgui.editor.document.graphical.edges.GraphicalEdge;
+import uniol.aptgui.editor.document.graphical.nodes.GraphicalNode;
+import uniol.aptgui.editor.layout.graphviz.GraphvizDocument;
+import uniol.aptgui.editor.layout.graphviz.GraphvizParser;
+import uniol.aptgui.editor.layout.graphviz.GraphvizRenderer;
+
+/**
+ * Simple layout algorithm that uses Graphviz to layout items.
+ */
+public class GraphvizLayout implements Layout {
+
+	private final Application application;
+	private final String graphvizCommand;
+
+	public GraphvizLayout(Application application, String graphvizCommand) {
+		this.application = application;
+		this.graphvizCommand = graphvizCommand;
+	}
+
+	@Override
+	public void applyTo(Document<?> document, int x0, int y0, int x1, int y1) {
+		// TODO: This ignores EditingOptions. How could they be integrated?
+		GraphvizDocument graphvizDoc = new GraphvizDocument(document);
+		try {
+			doLayout(graphvizDoc);
+		} catch (IOException | ParseException e) {
+			application.getMainWindow().showException("Layout exception", e);
+		}
+	}
+
+	@Override
+	public String getName() {
+		return "Graphviz";
+	}
+
+	private void doLayout(GraphvizDocument document) throws IOException, ParseException {
+		Process graphviz = new ProcessBuilder(graphvizCommand, "-Tplain")
+			.redirectError(ProcessBuilder.Redirect.INHERIT)
+			.start();
+		try {
+			// Write the input into DOT
+			try (OutputStream stream = graphviz.getOutputStream();
+					Writer osw = new OutputStreamWriter(stream, StandardCharsets.UTF_8);
+					Writer buf = new BufferedWriter(osw)) {
+				new GraphvizRenderer().writeDot(buf, document);
+				buf.close();
+			}
+
+			// Parse its output
+			GraphvizParser parser;
+			try (InputStream stream = graphviz.getInputStream();
+					Reader isr = new InputStreamReader(stream, StandardCharsets.UTF_8);
+					BufferedReader buf = new BufferedReader(isr)) {
+				parser = new GraphvizParser(buf);
+			}
+			applyLayout(document, parser);
+		} finally {
+			graphviz.destroy();
+		}
+	}
+
+	private void applyLayout(GraphvizDocument document, GraphvizParser parser) throws ParseException {
+		int height = parser.getHeight();
+		for (GraphvizParser.Node node : parser.getNodes()) {
+			GraphicalNode graphical = document.getNodeByID(node.getId());
+			if (graphical == null)
+				throw new ParseException("Could not find node with id " + node.getId());
+			graphical.setCenter(transformPoint(height, node.getPosition()));
+		}
+
+		for (GraphvizParser.Edge edge : parser.getEdges()) {
+			GraphicalEdge graphical = document.getEdgeByIDs(edge.getSource(), edge.getTarget());
+			if (graphical == null)
+				throw new ParseException("Could not find edge from " + edge.getSource() + " to " + edge.getTarget());
+
+			// First, remove all breakpoints
+			while (graphical.getBreakpointCount() != 0)
+				graphical.removeBreakpoint(0);
+
+			// Then, add new ones
+			for (Point point : edge.getBreakpoints()) {
+				graphical.addBreakpoint(transformPoint(height, point));
+			}
+
+			// And finally remove unnecessary breakpoints that Graphviz might have added
+			for (int i = 0; i < graphical.getBreakpointCount(); i++) {
+				if (!graphical.isBreakpointNecessary(i)) {
+					graphical.removeBreakpoint(i);
+					i--;
+				}
+			}
+		}
+	}
+
+	// Graphviz has the origin in bottom left, we don't. Fix this up by translating coordinates.
+	private Point transformPoint(int height, Point point) {
+		return new Point((int) point.getX(), height - (int) point.getY());
+	}
+
+}
+
+// vim: ft=java:noet:sw=8:sts=8:ts=8:tw=120

--- a/src/main/java/uniol/aptgui/editor/layout/graphviz/GraphvizDocument.java
+++ b/src/main/java/uniol/aptgui/editor/layout/graphviz/GraphvizDocument.java
@@ -1,0 +1,108 @@
+/*-
+ * APT - Analysis of Petri Nets and labeled Transition systems
+ * Copyright (C) 2016 Uli Schlachter
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package uniol.aptgui.editor.layout.graphviz;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.collections4.BidiMap;
+import org.apache.commons.collections4.bidimap.DualHashBidiMap;
+
+import uniol.apt.util.Pair;
+
+import uniol.aptgui.editor.document.Document;
+import uniol.aptgui.editor.document.graphical.GraphicalElement;
+import uniol.aptgui.editor.document.graphical.edges.GraphicalEdge;
+import uniol.aptgui.editor.document.graphical.nodes.GraphicalNode;
+
+/**
+ * Document state for GraphViz interaction.
+ */
+public class GraphvizDocument {
+
+	// Mapping between nodes and their names as given to graphviz
+	private final BidiMap<GraphicalNode, String> nodes = new DualHashBidiMap<>();
+
+	// Mapping between node names and the (unique) edge connecting these nodes
+	private final Map<Pair<String, String>, GraphicalEdge> edges = new HashMap<>();
+
+	public GraphvizDocument(Document<?> document) {
+		// Assign names to nodes
+		int counter = 0;
+		for (GraphicalElement elem : document.getGraphicalElements()) {
+			if (elem instanceof GraphicalNode) {
+				GraphicalNode node = (GraphicalNode) elem;
+				String id = String.format("s%d", counter++);
+				nodes.put(node, id);
+			}
+		}
+
+		// Save edges
+		for (GraphicalElement elem : document.getGraphicalElements()) {
+			if (elem instanceof GraphicalEdge) {
+				GraphicalEdge edge = (GraphicalEdge) elem;
+				String source = nodes.get(edge.getSource());
+				String target = nodes.get(edge.getTarget());
+				assert source != null;
+				assert target != null;
+
+				Pair<String, String> pair = new Pair<>(source, target);
+				Object old = edges.put(pair, edge);
+				assert old == null;
+			}
+		}
+	}
+
+	public GraphicalNode getNodeByID(String id) {
+		return nodes.getKey(id);
+	}
+
+	public String getNameOfNode(GraphicalNode node) {
+		return nodes.get(node);
+	}
+
+	public Collection<String> getNodeIDs() {
+		return nodes.values();
+	}
+
+	public GraphicalEdge getEdgeByIDs(String source, String target) {
+		return edges.get(new Pair<String, String>(source, target));
+	}
+
+	public Set<Pair<String, String>> getEdgeIDs() {
+		Set<Pair<String, String>> result = new HashSet<>();
+		for (GraphicalEdge edge : edges.values()) {
+			String source = getNameOfNode(edge.getSource());
+			String target = getNameOfNode(edge.getTarget());
+			assert source != null;
+			assert target != null;
+
+			Pair<String, String> pair = new Pair<>(source, target);
+			boolean added = result.add(pair);
+			assert added = true;
+		}
+		return result;
+	}
+}
+
+// vim: ft=java:noet:sw=8:sts=8:ts=8:tw=120

--- a/src/main/java/uniol/aptgui/editor/layout/graphviz/GraphvizParser.java
+++ b/src/main/java/uniol/aptgui/editor/layout/graphviz/GraphvizParser.java
@@ -1,0 +1,190 @@
+/*-
+ * APT - Analysis of Petri Nets and labeled Transition systems
+ * Copyright (C) 2016 Uli Schlachter
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package uniol.aptgui.editor.layout.graphviz;
+
+import java.awt.Point;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import uniol.apt.io.parser.ParseException;
+
+/**
+ * Parse dot's -Tplain output.
+ */
+public class GraphvizParser {
+
+	public static class Node {
+		private final String id;
+		private final Point position;
+
+		public Node(String id, Point position) {
+			this.id = id;
+			this.position = position;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Point getPosition() {
+			return position;
+		}
+	}
+
+	public static class Edge {
+		private final String source;
+		private final String target;
+		private final List<Point> breakpoints;
+
+		public Edge(String source, String target, List<Point> breakpoints) {
+			this.source = source;
+			this.target = target;
+			this.breakpoints = breakpoints;
+		}
+
+		public String getSource() {
+			return source;
+		}
+
+		public String getTarget() {
+			return target;
+		}
+
+		public List<Point> getBreakpoints() {
+			return breakpoints;
+		}
+	}
+
+	private int width;
+	private int height;
+	private final Set<Node> nodes = new HashSet<>();
+	private final Set<Edge> edges = new HashSet<>();
+
+	public GraphvizParser(BufferedReader reader) throws IOException, ParseException {
+		String line = "";
+
+		while (!line.equals("stop")) {
+			line = reader.readLine();
+			if (line == null)
+				throw new ParseException("Premature end of input");
+
+			String[] words = line.split(" ");
+			switch (words[0]) {
+				case "stop":
+					break;
+
+				case "graph":
+					handleGraph(words);
+					break;
+
+				case "node":
+					handleNode(words);
+					break;
+
+				case "edge":
+					handleEdge(words);
+					break;
+			}
+		}
+	}
+
+	private void handleGraph(String[] words) throws ParseException {
+		if (words.length < 4)
+			throw new ParseException("Invalid 'graph' line");
+		width = parseDoubleAndRound(words[2]);
+		height = parseDoubleAndRound(words[3]);
+	}
+
+	private void handleNode(String[] words) throws ParseException {
+		if (words.length < 4)
+			throw new ParseException("Invalid 'node' line");
+		String node = words[1];
+		int x = parseDoubleAndRound(words[2]);
+		int y = parseDoubleAndRound(words[3]);
+		nodes.add(new Node(node, new Point(x, y)));
+	}
+
+	private void handleEdge(String[] words) throws ParseException {
+		if (words.length < 6)
+			throw new ParseException("Invalid 'edge' line");
+		String source = words[1];
+		String target = words[2];
+		int numPoints = parseInteger(words[3]);
+
+		if (words.length < 4 + numPoints * 2)
+			throw new ParseException("Invalid 'edge' line");
+
+		List<Point> breakpoints = new ArrayList<>(numPoints);
+		for (int i = 0; i < numPoints; i++) {
+			int x = parseDoubleAndRound(words[4 + i*2]);
+			int y = parseDoubleAndRound(words[4 + i*2 + 1]);
+			breakpoints.add(new Point(x, y));
+		}
+
+		edges.add(new Edge(source, target, breakpoints));
+	}
+
+
+	private static int parseInteger(String s) throws ParseException {
+		try {
+			return Integer.parseInt(s);
+		} catch (NumberFormatException e) {
+			throw new ParseException(e);
+		}
+	}
+
+	private static double parseDouble(String s) throws ParseException {
+		try {
+			return Double.parseDouble(s);
+		} catch (NumberFormatException e) {
+			throw new ParseException(e);
+		}
+	}
+
+	private static int parseDoubleAndRound(String s) throws ParseException {
+		long result = Math.round(parseDouble(s));
+		if (result < Integer.MIN_VALUE || result > Integer.MAX_VALUE)
+			throw new ParseException("Value out of range for integer: " + s);
+		return (int) result;
+	}
+
+	public int getWidth() {
+		return width;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+
+	public Set<Node> getNodes() {
+		return Collections.unmodifiableSet(nodes);
+	}
+
+	public Set<Edge> getEdges() {
+		return Collections.unmodifiableSet(edges);
+	}
+}
+
+// vim: ft=java:noet:sw=8:sts=8:ts=8:tw=120

--- a/src/main/java/uniol/aptgui/editor/layout/graphviz/GraphvizRenderer.java
+++ b/src/main/java/uniol/aptgui/editor/layout/graphviz/GraphvizRenderer.java
@@ -1,0 +1,77 @@
+/*-
+ * APT - Analysis of Petri Nets and labeled Transition systems
+ * Copyright (C) 2016 Uli Schlachter
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package uniol.aptgui.editor.layout.graphviz;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+import java.awt.Point;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.apache.commons.collections4.BidiMap;
+import org.apache.commons.collections4.bidimap.DualHashBidiMap;
+
+import uniol.apt.adt.IEdge;
+import uniol.apt.adt.IGraph;
+import uniol.apt.util.Pair;
+
+import uniol.aptgui.editor.document.Document;
+import uniol.aptgui.editor.document.graphical.GraphicalElement;
+import uniol.aptgui.editor.document.graphical.edges.GraphicalEdge;
+import uniol.aptgui.editor.document.graphical.nodes.GraphicalNode;
+
+/**
+ * Write a GraphvizDocument into the DOT file format.
+ */
+public class GraphvizRenderer {
+
+	private static final String FILE_PREAMBLE = "digraph G {\n  splines=polyline;\n  node [fixedsize=true, width=60, height=60];\n";
+	private static final String FILE_POSTAMBLE = "}";
+
+	public void writeDot(Writer writer, GraphvizDocument document) throws IOException {
+		writer.append(FILE_PREAMBLE);
+
+		// Write all nodes
+		for (String nodeID : document.getNodeIDs()) {
+			writer.append("\"");
+			writer.append(nodeID);
+			writer.append("\";\n");
+		}
+
+		// Write all edges
+		for (Pair<String, String> edge : document.getEdgeIDs()) {
+			String source = edge.getFirst();
+			String target = edge.getSecond();
+
+			writer.append("\"");
+			writer.append(source);
+			writer.append("\" -> \"");
+			writer.append(target);
+			writer.append("\";\n");
+		}
+
+		writer.append(FILE_POSTAMBLE);
+	}
+}
+
+// vim: ft=java:noet:sw=8:sts=8:ts=8:tw=120

--- a/src/main/java/uniol/aptgui/mainwindow/menu/MenuViewImpl.java
+++ b/src/main/java/uniol/aptgui/mainwindow/menu/MenuViewImpl.java
@@ -37,6 +37,7 @@ import uniol.aptgui.mainwindow.WindowId;
 import uniol.aptgui.swing.JMenuBarView;
 import uniol.aptgui.swing.actions.CascadeWindowsAction;
 import uniol.aptgui.swing.actions.DeleteElementsAction;
+import uniol.aptgui.swing.actions.DotLayoutAction;
 import uniol.aptgui.swing.actions.ExitAction;
 import uniol.aptgui.swing.actions.ExportAction;
 import uniol.aptgui.swing.actions.ImportAction;
@@ -94,6 +95,7 @@ public class MenuViewImpl extends JMenuBarView<MenuPresenter> implements MenuVie
 	private final JMenu documentMenu;
 	private final JMenuItem renameDocument;
 	private final JMenuItem layoutRandom;
+	private final JMenuItem layoutDot;
 
 	private final JMenu moduleMenu;
 	private final JMenuItem moduleBrowser;
@@ -146,6 +148,7 @@ public class MenuViewImpl extends JMenuBarView<MenuPresenter> implements MenuVie
 		documentMenu = new JMenu("Document");
 		renameDocument = new JMenuItem(injector.getInstance(RenameDocumentAction.class));
 		layoutRandom = new JMenuItem(injector.getInstance(RandomLayoutAction.class));
+		layoutDot = new JMenuItem(injector.getInstance(DotLayoutAction.class));
 
 		// Modules
 		moduleMenu = new JMenu("Modules");
@@ -222,6 +225,7 @@ public class MenuViewImpl extends JMenuBarView<MenuPresenter> implements MenuVie
 
 		documentMenu.add(renameDocument);
 		documentMenu.add(layoutRandom);
+		documentMenu.add(layoutDot);
 
 	}
 

--- a/src/main/java/uniol/aptgui/swing/actions/DotLayoutAction.java
+++ b/src/main/java/uniol/aptgui/swing/actions/DotLayoutAction.java
@@ -1,0 +1,64 @@
+/*-
+ * APT - Analysis of Petri Nets and labeled Transition systems
+ * Copyright (C) 2016 Jonas Prellberg
+ * Copyright (C) 2016 Uli Schlachter
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package uniol.aptgui.swing.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+
+import com.google.common.eventbus.EventBus;
+import com.google.inject.Inject;
+
+import uniol.aptgui.Application;
+import uniol.aptgui.commands.ApplyLayoutCommand;
+import uniol.aptgui.editor.document.Document;
+import uniol.aptgui.editor.layout.GraphvizLayout;
+import uniol.aptgui.swing.Resource;
+import uniol.aptgui.swing.actions.base.DocumentAction;
+
+@SuppressWarnings("serial")
+public class DotLayoutAction extends DocumentAction {
+
+	private final GraphvizLayout graphvizLayout;
+
+	@Inject
+	public DotLayoutAction(Application app, EventBus eventBus, Application application) {
+		super(app, eventBus);
+		this.graphvizLayout = new GraphvizLayout(application, "dot");
+		String name = "Graphviz dot Layout";
+		putValue(NAME, name);
+		putValue(SHORT_DESCRIPTION, name);
+		putValue(SMALL_ICON, Resource.getIconLayout());
+		putValue(MNEMONIC_KEY, KeyEvent.VK_D);
+		setEnabled(false);
+		eventBus.register(this);
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		Document<?> document = app.getActiveDocument();
+		if (document != null) {
+			app.getHistory().execute(new ApplyLayoutCommand(document, graphvizLayout));
+		}
+	}
+
+}
+
+// vim: ft=java:noet:sw=8:sts=8:ts=8:tw=120


### PR DESCRIPTION
The (already existing) random layout assigns random positions to elements. This
commit adds a new layout which uses the dot program from the Grapvhiz tool set
to compute a layout.

This commit just adds the minimum necessary to get dot working. There are a
couple of obvious improvements that might be wanted:
- Support other graphviz tools, e.g. neato, twopi, circo, fdp, sfdp
- Honor EditingOptions (Snap-to-Grid; How?)
- Configurable path to the tool

To explain the last item a bit: Right now this uses a ProcesBuilder to start
"dot". This works on Linux if "dot" is in $PATH. On Windows this will break for
sure. To fix this, the path to the "dot" tool would need to be configurable.
Somehow...

This is a rewrite of the GraphvizLayout that I already had (and which was pretty ugly). Feel free to tell me that I am doing something wrong or that even the whole idea is bad and apt-gui should never use external tools like this.
